### PR TITLE
Add support to generate reports in different formats supported by pandas

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,6 +10,7 @@ pandas = "*"
 tabulate = "*"
 python-dateutil = "*"
 fire = "*"
+diskcache = "*"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "003e4b1a7014839cb7087349f973ddf490cfc0162cccb195262c5f25d5dd1c2e"
+            "sha256": "b2561130c48a0f88fd6b93de0c0f63c7317bec9eedddacc78a6a6314859d00b8"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -121,6 +121,14 @@
             "markers": "python_full_version >= '3.7.0'",
             "version": "==3.1.0"
         },
+        "diskcache": {
+            "hashes": [
+                "sha256:558c6a2d5d7c721bb00e40711803d6804850c9f76c426ed81ecc627fe9d2ce2d",
+                "sha256:e4c978532feff5814c4cc00fe1e11e40501985946643d73220d41ee7737c72c3"
+            ],
+            "index": "pypi",
+            "version": "==5.6.1"
+        },
         "exceptiongroup": {
             "hashes": [
                 "sha256:232c37c63e4f682982c8b6459f33a8981039e5fb8756b2074364e5055c498c9e",
@@ -234,11 +242,11 @@
         },
         "requests": {
             "hashes": [
-                "sha256:e8f3c9be120d3333921d213eef078af392fba3933ab7ed2d1cba3b56f2568c3b",
-                "sha256:f2e34a75f4749019bb0e3effb66683630e4ffeaf75819fb51bebef1bf5aef059"
+                "sha256:10e94cc4f3121ee6da529d358cdaeaff2f1c409cd377dbc72b825852f2f7e294",
+                "sha256:239d7d4458afcb28a692cdd298d87542235f4ca8d36d03a15bfc128a6559a2f4"
             ],
             "index": "pypi",
-            "version": "==2.29.0"
+            "version": "==2.30.0"
         },
         "requests-cache": {
             "hashes": [
@@ -290,11 +298,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305",
-                "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"
+                "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc",
+                "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.26.15"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.2"
         }
     },
     "develop": {
@@ -529,11 +537,11 @@
         },
         "griffe": {
             "hashes": [
-                "sha256:833990074c8c0b323a55f37f72265fdd841cb0a756122303505bf4bc80800e82",
-                "sha256:8d6bc40e7bede3fb5879598c1f71b8902d245804ab59ae55516f864b2bdc25c6"
+                "sha256:094513b209d4acd4b2680c2415d3af5f8ed925714795380c2a7d070e222e0b27",
+                "sha256:a3d0f75aa76b80f181f818cf605f658a69fccf287aaeeeafc7a6cf4e6a2ca27e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==0.27.2"
+            "version": "==0.27.3"
         },
         "idna": {
             "hashes": [
@@ -980,34 +988,34 @@
         },
         "requests": {
             "hashes": [
-                "sha256:e8f3c9be120d3333921d213eef078af392fba3933ab7ed2d1cba3b56f2568c3b",
-                "sha256:f2e34a75f4749019bb0e3effb66683630e4ffeaf75819fb51bebef1bf5aef059"
+                "sha256:10e94cc4f3121ee6da529d358cdaeaff2f1c409cd377dbc72b825852f2f7e294",
+                "sha256:239d7d4458afcb28a692cdd298d87542235f4ca8d36d03a15bfc128a6559a2f4"
             ],
             "index": "pypi",
-            "version": "==2.29.0"
+            "version": "==2.30.0"
         },
         "ruff": {
             "hashes": [
-                "sha256:04ec5d75e4bca754cedd20d53e2ba4920d6259e7579abfb2e8e30c3c80e41b17",
-                "sha256:05ee163a046fc593d150179d23f4af447fb82f3e59cd34e031ea0868c65bb8e8",
-                "sha256:068a82a29d80848a56e3d9d4308e6e0ca8b2ecdaf5ac342a292545a59b7f2c21",
-                "sha256:18a29ed37bf8cfe6dce8a2db56c313a64c0804095108753621f3c3321e0c9c5f",
-                "sha256:323ae6c1702b26c96d0fbf939c5959c37e79021f86b70f63634df918bc77f36e",
-                "sha256:3e2c38449548e122f2612843a7c04e22b4fd491656955c57b8cb05df11639ad6",
-                "sha256:4564e0f245eb515c6ed63988c21e9c40bcfd485cd1ec63bdd790f9a81d301f15",
-                "sha256:484e395d1984ab9e1e66bd42e7a5192decfee86998d07d36ee50b2fadccc8734",
-                "sha256:5a8658ebcc37d62f72840cbdf564171c1a2b6831db482b4d917962541a2f4a44",
-                "sha256:67326fdc9ac0a1b13e229c6e24e8d115863c52cd710faaaaa588851535281d6c",
-                "sha256:71fd865ebacc1083259b3fb7e3eb45235a86e62e21830b8a6b067be0ec54aa2e",
-                "sha256:8fcd4b693ca1374eb7a5796581c90689f884f98f388740d94f0702fd30f8f78f",
-                "sha256:91c6eb4f979b661a2dd850d9ac803842bb7b66d4926de84f09c787af82590f73",
-                "sha256:cd4f60ffc3eb15802c554a9c8581bf2117c4d3d06fbc57e0ba58f04cb1aaa47f",
-                "sha256:d628de91e2be7a83128526636097d2dd890669a06143f826f6c591d79aeefbc4",
-                "sha256:d97ba8db0fb601ffe9ee996ebb97c698e427a2fd4514fefbe7b803111354f783",
-                "sha256:ec2fa192c035b8b68cc2b91049c561cd69543e2b8c4d157d9aa7727320bedcca"
+                "sha256:1d5a8de2fbaf91ea5699451a06f4074e7a312accfa774ad9327cde3e4fda2081",
+                "sha256:2a9b38bdb40a998cbc677db55b6225a6c4fadcf8819eb30695e1b8470942426b",
+                "sha256:30ddfe22de6ce4eb1260408f4480bbbce998f954dbf470228a21a9b2c45955e4",
+                "sha256:4057eb539a1d88eb84e9f6a36e0a999e0f261ed850ae5d5817e68968e7b89ed9",
+                "sha256:5028950f7af9b119d43d91b215d5044976e43b96a0d1458d193ef0dd3c587bf8",
+                "sha256:53c17f0dab19ddc22b254b087d1381b601b155acfa8feed514f0d6a413d0ab3a",
+                "sha256:62a9578b48cfd292c64ea3d28681dc16b1aa7445b7a7709a2884510fc0822118",
+                "sha256:9ac13b11d9ad3001de9d637974ec5402a67cefdf9fffc3929ab44c2fcbb850a1",
+                "sha256:9e9db5ccb810742d621f93272e3cc23b5f277d8d00c4a79668835d26ccbe48dd",
+                "sha256:a11bd0889e88d3342e7bc514554bb4461bf6cc30ec115821c2425cfaac0b1b6a",
+                "sha256:a8b44a245b60512403a6a03a5b5212da274d33862225c5eed3bcf12037eb19bb",
+                "sha256:aa17b13cd3f29fc57d06bf34c31f21d043735cc9a681203d634549b0e41047d1",
+                "sha256:b279fa55ea175ef953208a6d8bfbcdcffac1c39b38cdb8c2bfafe9222add70bb",
+                "sha256:c78470656e33d32ddc54e8482b1b0fc6de58f1195586731e5ff1405d74421499",
+                "sha256:d0f9967f84da42d28e3d9d9354cc1575f96ed69e6e40a7d4b780a7a0418d9409",
+                "sha256:d586e69ab5cbf521a1910b733412a5735936f6a610d805b89d35b6647e2a66aa",
+                "sha256:f54facf286103006171a00ce20388d88ed1d6732db3b49c11feb9bf3d46f90e9"
             ],
             "index": "pypi",
-            "version": "==0.0.264"
+            "version": "==0.0.265"
         },
         "six": {
             "hashes": [
@@ -1027,11 +1035,11 @@
         },
         "urllib3": {
             "hashes": [
-                "sha256:8a388717b9476f934a21484e8c8e61875ab60644d29b9b39e11e4b9dc1c6b305",
-                "sha256:aa751d169e23c7479ce47a0cb0da579e3ede798f994f5816a74e4f4500dcea42"
+                "sha256:61717a1095d7e155cdb737ac7bb2f4324a858a1e2e6466f6d03ff630ca68d3cc",
+                "sha256:d055c2f9d38dc53c808f6fdc8eab7360b6fdbbde02340ed25cfbcd817c62469e"
             ],
-            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'",
-            "version": "==1.26.15"
+            "markers": "python_version >= '3.7'",
+            "version": "==2.0.2"
         },
         "watchdog": {
             "hashes": [

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -10,7 +10,7 @@ coveralls==3.3.1
 docopt==0.6.2
 exceptiongroup==1.1.1 ; python_version < '3.11'
 ghp-import==2.1.0
-griffe==0.27.2 ; python_version >= '3.7'
+griffe==0.27.3 ; python_version >= '3.7'
 idna==3.4 ; python_version >= '3.5'
 iniconfig==2.0.0 ; python_version >= '3.7'
 isort==5.12.0
@@ -45,14 +45,15 @@ python-dateutil==2.8.2
 pyyaml==6.0 ; python_version >= '3.6'
 pyyaml-env-tag==0.1 ; python_version >= '3.6'
 regex==2023.5.5 ; python_version >= '3.6'
-requests==2.29.0
-ruff==0.0.264
+requests==2.30.0
+ruff==0.0.265
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 tomli==2.0.1 ; python_version < '3.11'
-urllib3==1.26.15 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+urllib3==2.0.2 ; python_version >= '3.7'
 watchdog==3.0.0 ; python_version >= '3.7'
 attrs==23.1.0 ; python_version >= '3.7'
 cattrs==22.2.0 ; python_version >= '3.7'
+diskcache==5.6.1
 fire==0.5.0
 numpy==1.24.3 ; python_version >= '3.10'
 pandas==2.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ attrs==23.1.0 ; python_version >= '3.7'
 cattrs==22.2.0 ; python_version >= '3.7'
 certifi==2022.12.7 ; python_version >= '3.6'
 charset-normalizer==3.1.0 ; python_full_version >= '3.7.0'
+diskcache==5.6.1
 exceptiongroup==1.1.1 ; python_version < '3.11'
 fire==0.5.0
 idna==3.4 ; python_version >= '3.5'
@@ -11,11 +12,11 @@ pandas==2.0.1
 platformdirs==3.5.0 ; python_version >= '3.7'
 python-dateutil==2.8.2
 pytz==2023.3
-requests==2.29.0
+requests==2.30.0
 requests-cache==1.0.1
 six==1.16.0 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'
 tabulate==0.9.0
 termcolor==2.3.0 ; python_version >= '3.7'
 tzdata==2023.3 ; python_version >= '2'
 url-normalize==1.4.3 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
-urllib3==1.26.15 ; python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3, 3.4, 3.5'
+urllib3==2.0.2 ; python_version >= '3.7'

--- a/src/stocktracer/analysis/diluted_eps.py
+++ b/src/stocktracer/analysis/diluted_eps.py
@@ -30,7 +30,7 @@ def trendline(data: pd.Series, order: int = 1) -> float:
     return float(slope)
 
 
-def analyze(options: Options) -> None:
+def analyze(options: Options) -> pd.DataFrame:
     """Perform an analysis on the earnings per share over time
 
     Args:
@@ -62,6 +62,7 @@ def analyze(options: Options) -> None:
             logger.warning(f"{t}: {ex}")
 
     print(f"Trends:\n{results}")
+    return results
 
 
 def report(options: ReportOptions) -> None:

--- a/src/stocktracer/analysis/stub.py
+++ b/src/stocktracer/analysis/stub.py
@@ -7,17 +7,21 @@ from stocktracer.cli import Options, ReportOptions
 logger = logging.getLogger(__name__)
 
 
-def analyze(options: Options) -> None:
+def analyze(options: Options) -> pd.DataFrame:
     """Analyze the report
 
     As a stub, this does nothing
 
     Args:
         options (Options): options to use for processing
+
+    Returns:
+        pd.DataFrame: Containing the results of the report
     """
     print(
         "This is where we would start to process information, but we're not right now"
     )
+    return pd.DataFrame()
 
 
 def report(options: ReportOptions) -> None:

--- a/src/tests/analysis/test_stub.py
+++ b/src/tests/analysis/test_stub.py
@@ -20,9 +20,7 @@ class TestCli:
         self.cli.export(tickers=["aapl"], analysis_plugin="stocktracer.analysis.stub")
 
     def test_invalid(self):
-        try:
+        with pytest.raises(LookupError, match="No analysis results available!"):
             self.cli.export(
                 tickers="invalid", analysis_plugin="stocktracer.analysis.stub"
             )
-        except ZeroDivisionError as exc:
-            pytest.fail(exc, pytrace=True)

--- a/src/tests/analysis/test_stub.py
+++ b/src/tests/analysis/test_stub.py
@@ -12,7 +12,9 @@ class TestCli:
     cli: Cli = Cli()
 
     def test_analyze(self):
-        self.cli.analyze(tickers=["aapl"], analysis_plugin="stocktracer.analysis.stub")
+        self.cli.analyze(
+            refresh=True, tickers=["aapl"], analysis_plugin="stocktracer.analysis.stub"
+        )
 
     def test_export(self):
         self.cli.export(tickers=["aapl"], analysis_plugin="stocktracer.analysis.stub")


### PR DESCRIPTION
# Description

Adds support for exporting data sets using different pandas formats

Fixes #25

## Type of change

<!-- Please delete options that are not relevant. -->

- [x] New feature (non-breaking change which adds functionality)
- [x] This change requires a documentation update

# How Has This Been Tested?

<!-- Please describe the tests that you ran to verify your changes. 
Provide instructions so we can reproduce. Please also list any relevant details 
for your test configuration -->

- [ ] Unit tests and requires no additional network access
- [ ] Unit tests and requires network access. I have annotated these tests with `@pytest.mark.webtest`.
- [ ] Manually


# Checklist:

- [ ] I have run `auto-format.sh`
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
